### PR TITLE
NXP-31023: save compound document folders with correct title

### DIFF
--- a/nuxeo-compound-documents/src/main/java/org/nuxeo/compound/documents/CompoundDocumentServiceImpl.java
+++ b/nuxeo-compound-documents/src/main/java/org/nuxeo/compound/documents/CompoundDocumentServiceImpl.java
@@ -119,7 +119,7 @@ public class CompoundDocumentServiceImpl extends DefaultComponent implements Com
         String entryDocName = entryPath.lastSegment();
         if (entry.isDirectory()) {
             var doc = session.createDocumentModel(parentDocPath, entryDocName, compoundFolderType);
-            compoundDoc.setPropertyValue("dc:title", entryDocName);
+            doc.setPropertyValue("dc:title", entryDocName);
             session.createDocument(doc);
         } else {
             var blob = new ZipEntryBlob(zip, entry);


### PR DESCRIPTION
During functional tests, I noticed that the `CompoundDocumentFolder`s, were not created with the correct `dc:title`.