### PR TITLE
NXBT-3639: Use a former version of Bitnami Chart repository descriptor

### DIFF
--- a/ci/helm/helmfile.yaml
+++ b/ci/helm/helmfile.yaml
@@ -1,6 +1,8 @@
 repositories:
 - name: bitnami
-  url: https://charts.bitnami.com/bitnami
+  # use a former version of index.yaml from the git repository as Bitnami all removed charts older than 6 months from
+  # the index.yaml descriptor, see https://github.com/bitnami/charts/issues/10539
+  url: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
 - name: elastic
   url: https://helm.elastic.co/
 - name: nuxeo


### PR DESCRIPTION
Due to the new retention policy of 6 months on Bitnami Chart repository, see https://github.com/bitnami/charts/issues/10539