### PR TITLE
NXP-31126: introduce compound documents breadcrumb enricher

### DIFF
--- a/nuxeo-compound-documents/src/main/java/org/nuxeo/compound/documents/CompoundDocumentBreadcrumbJsonEnricher.java
+++ b/nuxeo-compound-documents/src/main/java/org/nuxeo/compound/documents/CompoundDocumentBreadcrumbJsonEnricher.java
@@ -1,0 +1,81 @@
+/*
+ * (C) Copyright 2022 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.nuxeo.compound.documents;
+
+import static org.nuxeo.compound.documents.CompoundDocumentConstants.COMPOUND_DOCUMENT_FACET;
+import static org.nuxeo.ecm.core.io.registry.reflect.Instantiations.SINGLETON;
+import static org.nuxeo.ecm.core.io.registry.reflect.Priorities.REFERENCE;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.impl.DocumentModelListImpl;
+import org.nuxeo.ecm.core.io.marshallers.json.document.DocumentModelListJsonWriter;
+import org.nuxeo.ecm.core.io.marshallers.json.enrichers.AbstractJsonEnricher;
+import org.nuxeo.ecm.core.io.registry.context.RenderingContext.SessionWrapper;
+import org.nuxeo.ecm.core.io.registry.reflect.Setup;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+/**
+ * Enrich {@link DocumentModel} Json.
+ * <p>
+ * Add compound document breadcrumb (list of all compound document ancestors) as json attachment.
+ * <p>
+ * Enable if parameter enrichers-document=compoundDocumentBreadcrumb is present.
+ * <p>
+ * Format is:
+ *
+ * <pre>
+ * {
+ *   "entity-type":"document",
+ *   ...
+ *   "contextParameters": {
+ *     "compoundDocumentBreadcrumb": { see {@link DocumentModelListJsonWriter} for format }
+ *   }
+ * }
+ * </pre>
+ *
+ * @since 2021.0
+ */
+@Setup(mode = SINGLETON, priority = REFERENCE)
+public class CompoundDocumentBreadcrumbJsonEnricher extends AbstractJsonEnricher<DocumentModel> {
+
+    public static final String NAME = "compoundDocumentBreadcrumb";
+
+    public CompoundDocumentBreadcrumbJsonEnricher() {
+        super(NAME);
+    }
+
+    @Override
+    public void write(JsonGenerator jg, DocumentModel document) throws IOException {
+        try (SessionWrapper wrapper = ctx.getSession(document)) {
+            if (!wrapper.getSession().exists(document.getRef())) {
+                return;
+            }
+            var parentCompounds = wrapper.getSession()
+                                         .getParentDocuments(document.getRef())
+                                         .stream()
+                                         .filter(d -> d.hasFacet(COMPOUND_DOCUMENT_FACET))
+                                         .collect(Collectors.toCollection(DocumentModelListImpl::new));
+            jg.writeFieldName(NAME);
+            writeEntity(parentCompounds, jg);
+        }
+    }
+
+}

--- a/nuxeo-compound-documents/src/main/java/org/nuxeo/compound/documents/CompoundDocumentConstants.java
+++ b/nuxeo-compound-documents/src/main/java/org/nuxeo/compound/documents/CompoundDocumentConstants.java
@@ -23,6 +23,8 @@ public final class CompoundDocumentConstants {
         // Utility class
     }
 
+    public static final String COMPOUND_DOCUMENT_FACET = "CompoundDocument";
+
     public static final String COMPOUND_DOCTYPE_DETECTION_OPERATION = "javascript.GetCompoundDocumentType";
 
     public static final String COMPOUND_FOLDER_DOCTYPE_DETECTION_OPERATION = "javascript.GetCompoundDocumentFolderType";

--- a/nuxeo-compound-documents/src/main/resources/META-INF/MANIFEST.MF
+++ b/nuxeo-compound-documents/src/main/resources/META-INF/MANIFEST.MF
@@ -7,4 +7,5 @@ Nuxeo-Component: OSGI-INF/core-types-contrib.xml,
  OSGI-INF/filemanager-contrib.xml,
  OSGI-INF/service-contrib.xml,
  OSGI-INF/operations-contrib.xml,
- OSGI-INF/thumbnailfactory-contrib.xml
+ OSGI-INF/thumbnailfactory-contrib.xml,
+ OSGI-INF/marshallers-contrib.xml

--- a/nuxeo-compound-documents/src/main/resources/OSGI-INF/marshallers-contrib.xml
+++ b/nuxeo-compound-documents/src/main/resources/OSGI-INF/marshallers-contrib.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.compound.documents.marshallers" version="1.0.0">
+  <extension target="org.nuxeo.ecm.core.io.MarshallerRegistry" point="marshallers">
+    <register class="org.nuxeo.compound.documents.CompoundDocumentBreadcrumbJsonEnricher" enable="true" />
+  </extension>
+</component>

--- a/nuxeo-compound-documents/src/test/java/org/nuxeo/compound/documents/TestCompoundDocumentBreadcrumbJsonEnricher.java
+++ b/nuxeo-compound-documents/src/test/java/org/nuxeo/compound/documents/TestCompoundDocumentBreadcrumbJsonEnricher.java
@@ -1,0 +1,78 @@
+/*
+ * (C) Copyright 2022 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.nuxeo.compound.documents;
+
+import static org.nuxeo.compound.documents.CompoundDocumentBreadcrumbJsonEnricher.NAME;
+import static org.nuxeo.compound.documents.CompoundDocumentUtils.COMPOUND_DOCTYPE;
+import static org.nuxeo.compound.documents.CompoundDocumentUtils.COMPOUND_FOLDER_DOCTYPE;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.io.marshallers.json.AbstractJsonWriterTest;
+import org.nuxeo.ecm.core.io.marshallers.json.JsonAssert;
+import org.nuxeo.ecm.core.io.marshallers.json.document.DocumentModelJsonWriter;
+import org.nuxeo.ecm.core.io.registry.context.RenderingContext.CtxBuilder;
+import org.nuxeo.ecm.core.test.annotations.Granularity;
+import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+
+/** @since 2021.0 */
+@RunWith(FeaturesRunner.class)
+@Features(CompoundDocumentsFeature.class)
+@RepositoryConfig(cleanup = Granularity.METHOD)
+public class TestCompoundDocumentBreadcrumbJsonEnricher
+        extends AbstractJsonWriterTest<DocumentModelJsonWriter, DocumentModel> {
+
+    @Inject
+    protected CoreSession session;
+
+    public TestCompoundDocumentBreadcrumbJsonEnricher() {
+        super(DocumentModelJsonWriter.class, DocumentModel.class);
+    }
+
+    @Test
+    public void test() throws IOException {
+        var level1Doc = session.createDocumentModel("/", "level1", COMPOUND_DOCTYPE);
+        session.createDocument(level1Doc);
+        var level2Doc = session.createDocumentModel("/level1/", "level2", COMPOUND_FOLDER_DOCTYPE);
+        session.createDocument(level2Doc);
+        var level3Doc = session.createDocumentModel("/level1/level2", "level3", COMPOUND_DOCTYPE);
+        session.createDocument(level3Doc);
+        var level4Doc = session.createDocumentModel("/level1/level2/level3", "level4", "File");
+        level4Doc = session.createDocument(level4Doc);
+
+        JsonAssert json = jsonAssert(level4Doc, CtxBuilder.enrichDoc(NAME).get());
+        json = json.has("contextParameters").isObject();
+        json.properties(1);
+        json = json.has(NAME).isObject();
+        json.has("entity-type").isEquals("documents");
+        json = json.has("entries").length(2);
+        JsonAssert doc = json.has(0);
+        doc.has("entity-type").isEquals("document");
+        doc.has("title").isEquals("level1");
+        doc = json.has(1);
+        doc.has("entity-type").isEquals("document");
+        doc.has("title").isEquals("level3");
+    }
+}

--- a/nuxeo-compound-documents/src/test/java/org/nuxeo/compound/documents/TestCompoundDocumentImporter.java
+++ b/nuxeo-compound-documents/src/test/java/org/nuxeo/compound/documents/TestCompoundDocumentImporter.java
@@ -54,6 +54,7 @@ import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
 import org.nuxeo.runtime.test.runner.TransactionalFeature;
 
+/** @since 2021.0 */
 @RunWith(FeaturesRunner.class)
 @Features(CompoundDocumentsFeature.class)
 @RepositoryConfig(cleanup = Granularity.METHOD)

--- a/nuxeo-compound-documents/src/test/java/org/nuxeo/compound/documents/TestCompoundDocumentRest.java
+++ b/nuxeo-compound-documents/src/test/java/org/nuxeo/compound/documents/TestCompoundDocumentRest.java
@@ -54,6 +54,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource.Builder;
 
+/** @since 2021.0 */
 @RunWith(FeaturesRunner.class)
 @Features(CompoundDocumentsFeature.class)
 @RepositoryConfig(cleanup = Granularity.METHOD)


### PR DESCRIPTION
New Compound Document Breadcrumbs to allow searching compounds by the tags and full text of their assets as aggregates.