### PR TITLE
NXP-31368: set geckodriverVersion to 0.30.0

### DIFF
--- a/nuxeo-compound-documents-web/karma.conf.js
+++ b/nuxeo-compound-documents-web/karma.conf.js
@@ -28,6 +28,7 @@ if (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) {
       browserName: 'firefox',
       platform: 'Windows 10',
       version: 'latest',
+      geckodriverVersion: '0.30.0',
     },
     sl_latest_edge: {
       base: 'SauceLabs',


### PR DESCRIPTION
https://saucelabs.com/blog/update-firefox-tests-before-oct-4-2022